### PR TITLE
refactor: unamed args for simpler shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ quarto install extension sellorm/quarto-twitter-embed
 
 To embed a video into your Quarto html document you can use the shortcode like this:
 
-```
-{{< tweet user="USERNAME" id="STATUS_ID" >}}
+```markdown
+{{< tweet <username> <id> >}}
 ```
 
 For example:
 
-```
-{{< tweet user="sellorm" id="1555267341327503367" >}}
+```markdown
+{{< tweet sellorm 1555267341327503367 >}}
 ```
 
 You can obtain the username and status id of a tweet by clicking the "share tweet" button and choosing "copy URL".
 
-This will give you a URL like this one: `https://twitter.com/sellorm/status/1555267341327503367?s=21&t=M0M4IA_KW-zMY1rb2XOWZQ`. The "user" is the section between `twitter.com/` and `/status`. The status "id" is everything between `status/` and `?` or the end of the URL, whichever comes first.
+This will give you a URL like this one: `https://twitter.com/sellorm/status/1555267341327503367?s=21&t=M0M4IA_KW-zMY1rb2XOWZQ`.
+The "user" is the section between `twitter.com/` and `/status`.
+The status "id" is everything between `status/` and `?` or the end of the URL, whichever comes first.
 
 See `example.qmd` for a full example.
-

--- a/README.md
+++ b/README.md
@@ -18,10 +18,22 @@ To embed a video into your Quarto html document you can use the shortcode like t
 {{< tweet <username> <id> >}}
 ```
 
+or
+
+```markdown
+{{< tweet user=<username> id=<id> >}}
+```
+
 For example:
 
 ```markdown
 {{< tweet sellorm 1555267341327503367 >}}
+```
+
+or
+
+```markdown
+{{< tweet user=sellorm id=1555267341327503367 >}}
 ```
 
 You can obtain the username and status id of a tweet by clicking the "share tweet" button and choosing "copy URL".

--- a/_extensions/twitter/twitter.lua
+++ b/_extensions/twitter/twitter.lua
@@ -11,19 +11,31 @@ local function ensureHtmlDeps()
         }
     })
 end
+   
+local function isEmpty(s)
+    return s == nil or s == ''
+end
 
 function tweet(args, kwargs)
     if quarto.doc.isFormat('html') then
         ensureHtmlDeps()
-        local user = pandoc.utils.stringify(args[1])
-        local status_id = pandoc.utils.stringify(args[2])
-        
+
+        if isEmpty(args[1]) then
+            user = pandoc.utils.stringify(kwargs["user"])
+            status_id = pandoc.utils.stringify(kwargs["id"])
+        else
+            user = pandoc.utils.stringify(args[1])
+            status_id = pandoc.utils.stringify(args[2])
+        end
+
         -- Assemble the twitter oembed API URL from the user inputs
         local tweet_embed = 'https://publish.twitter.com/oembed?url=https://twitter.com/' 
             .. user
             .. '/status/'
             .. status_id
             .. '&align=center'
+
+        print(tweet_embed)
         
         local mt, api_resp = pandoc.mediabag.fetch(tweet_embed)
         

--- a/_extensions/twitter/twitter.lua
+++ b/_extensions/twitter/twitter.lua
@@ -1,39 +1,43 @@
-function tweet(args, kwargs)
-    local user = pandoc.utils.stringify(kwargs["user"])
-    local status_id = pandoc.utils.stringify(kwargs["id"])
-    
-    -- Assemble the twitter oembed API URL from the user inputs
-    local tweet_embed = 'https://publish.twitter.com/oembed?url=https://twitter.com/' 
-      .. user
-      .. '/status/'
-      .. status_id
-      .. '&align=center'
-    
-    local mt, api_resp = pandoc.mediabag.fetch(tweet_embed)
-    
-    -- generate a random number to append to the html div ID to avoid re-use
-    local id = math.random(10000, 99999)
-
-    local tweet_data = '<div id="tweet-'
-       .. id 
-       .. '"></div><script>tweet=' 
-       .. api_resp 
-       .. ';document.getElementById("tweet-' 
-       .. id 
-       .. '").innerHTML = tweet["html"];</script>'
-    
-    if quarto.doc.isFormat('html') then
-        quarto.doc.addHtmlDependency({
-            name = "twitter",
-            
-            scripts = {
-                { 
-                    path = "",
-                    attribs = {src="https://platform.twitter.com/widgets.js"},
-                    afterBody = true
-                }
+local function ensureHtmlDeps()
+    quarto.doc.addHtmlDependency({
+        name = 'twitter',
+        version = '0.0.1',
+        scripts = {
+            { 
+                path = "",
+                attribs = {src="https://platform.twitter.com/widgets.js"},
+                afterBody = true
             }
-        })
+        }
+    })
+end
+
+function tweet(args, kwargs)
+    if quarto.doc.isFormat('html') then
+        ensureHtmlDeps()
+        local user = pandoc.utils.stringify(args[1])
+        local status_id = pandoc.utils.stringify(args[2])
+        
+        -- Assemble the twitter oembed API URL from the user inputs
+        local tweet_embed = 'https://publish.twitter.com/oembed?url=https://twitter.com/' 
+            .. user
+            .. '/status/'
+            .. status_id
+            .. '&align=center'
+        
+        local mt, api_resp = pandoc.mediabag.fetch(tweet_embed)
+        
+        -- generate a random number to append to the html div ID to avoid re-use
+        local id = math.random(10000, 99999)
+
+        local tweet_data = '<div id="tweet-'
+            .. id 
+            .. '"></div><script>tweet=' 
+            .. api_resp 
+            .. ';document.getElementById("tweet-' 
+            .. id 
+            .. '").innerHTML = tweet["html"];</script>'
+
         return pandoc.RawInline('html', tweet_data)
     else
         return pandoc.Null()

--- a/example.qmd
+++ b/example.qmd
@@ -6,17 +6,20 @@ format: html
 
 ## Here is a Tweet 
 
-This is a fun tweet I tweeted:
+This is a fun tweet I tweeted: `{{{< tweet sellorm 1555267341327503367 >}}}`
 
-{{< tweet user="sellorm" id="1555267341327503367" >}}
+Rendered as:
+
+{{< tweet sellorm 1555267341327503367 >}}
 
 Duke Caboom _is_ pretty great!
 
 ---
 
-Here's another tweet:
+Here's another tweet: `{{{< tweet rstudio 1552285282636120064 >}}}`
 
-{{< tweet user="rstudio" id="1552285282636120064" >}}
+Rendered as:
+
+{{< tweet rstudio 1552285282636120064 >}}
 
 Exciting news!
-


### PR DESCRIPTION
This PR proposed to not use named argument to have a simpler shortcode to type.
It also refactor a bit the lua filter, to perform computation only if the format is HTML, i.e., no need to parse the shortcode for other formats.

```markdown
{{< tweet <username> <id> >}}
```